### PR TITLE
Make chores fork from develop unless hotfix label

### DIFF
--- a/lib/github_pivotal_flow/story.rb
+++ b/lib/github_pivotal_flow/story.rb
@@ -166,7 +166,7 @@ module GithubPivotalFlow
     def root_branch_name
       case story_type
       when 'chore'
-        master_branch_name
+        self.labels.include?('hotfix') ? master_branch_name : development_branch_name
       when 'bug'
         self.labels.include?('hotfix') ? master_branch_name : development_branch_name
       else


### PR DESCRIPTION
Chores are very similar to features (except they don't face end-user), unless they're a severe job that needs to be done right now and in master, so I would propose to also take a look if chore has a hotfix tag on it, otherwise fork from develop branch.

Thanks!