### PR TITLE
Hotfix should merge to master and develop, and branches should be able to specify a root branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ $ git start
 Choose story to start:
 ```
 
+### hotfix
+    Will start a branch from master and set it up to merge back to master and to your develop branch
+
+```plain
+    $ git start story-id --hotfix
+```
+
+
+
 Once a story has been selected by one of the three methods, the command then prompts for the name of the branch to create.
 
 ```plain

--- a/README.md
+++ b/README.md
@@ -101,9 +101,17 @@ Choose story to start:
 
 ```plain
     $ git start story-id --hotfix
+    OR
+    $ git start story-id -f
 ```
 
-
+### root_branch
+    Will start a branch from the passed in root_branch_name and set it up to merge back to the same branch
+```plain
+    $ git start story-id --root-branch-name=BRANCH_NAME
+    OR
+    $ git start story-id -r BRANCH_NAME
+```
 
 Once a story has been selected by one of the three methods, the command then prompts for the name of the branch to create.
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ $ gem install github-pivotal-flow
 The typical workflow looks something like the following:
 
 ```plain
-$ git start       # Creates branch from your [development] branch and starts story
+$ git start             # Creates branch from your [development] branch and starts story
+$ git start STORY_ID    # Optionally pass the story ID from pivotal
+$ git start STORY_ID -f # If the story is a hotfix, we'll brnach from your [master] branch and start story, then merge to both the [development] and [master] branch on finish
+$ git start STORY_ID -r ROOT_BRANCH_NAME # Optionally pass a root branch name. Common scenario is branching off of a Release branch
 $ git commit ...
 $ git commit ...  # Your existing development process
 $ git commit ...
-$ git publish ... # Push the branch out to origin and open a pull request on github to gather some feedback
+$ git publish ... # Push the branch out to origin and open a pull request on github to gather some feedback. Make sure you have at least one commit (this goes for release branches too)
 $ git finish      # Merges back into the main branch. Pushes to origin, destroys branch and finishes story.
 ```
 

--- a/lib/github_pivotal_flow.rb
+++ b/lib/github_pivotal_flow.rb
@@ -31,6 +31,8 @@ module GithubPivotalFlow
   KEY_RELEASE_PREFIX = 'gitflow.prefix.release'.freeze
   KEY_DEVELOPMENT_BRANCH = 'gitflow.branch.develop'.freeze
   KEY_MASTER_BRANCH = 'gitflow.branch.master'.freeze
+  KEY_ROOT_BRANCH = 'root-branch'.freeze
+  KEY_ROOT_REMOTE = 'root-remote'.freeze
   KEY_GITHUB_USERNAME = 'github.username'.freeze
   KEY_GITHUB_API_TOKEN = 'github.api-token'.freeze
 end

--- a/lib/github_pivotal_flow/publish.rb
+++ b/lib/github_pivotal_flow/publish.rb
@@ -8,12 +8,10 @@ module GithubPivotalFlow
       fail("Could not find story associated with branch") unless story
       Git.clean_working_tree?
       Git.push(story.branch_name, set_upstream: true)
-      unless story.release?
-        print "Creating pull-request on Github... "
-        pull_request_params = story.params_for_pull_request.merge(project: @configuration.project)
-        @configuration.github_client.create_pullrequest(pull_request_params)
-        puts 'OK'
-      end
+      print "Creating pull-request on Github... "
+      pull_request_params = story.params_for_pull_request.merge(project: @configuration.project)
+      @configuration.github_client.create_pullrequest(pull_request_params)
+      puts 'OK'
       return 0
     end
 

--- a/lib/github_pivotal_flow/start.rb
+++ b/lib/github_pivotal_flow/start.rb
@@ -1,13 +1,14 @@
 # The class that encapsulates starting a Pivotal Tracker Story
 module GithubPivotalFlow
   class Start < GithubPivotalFlow::Command
+
     def run!
       filter = [@options[:args]].flatten.first
       #TODO: Validate the format of the filter argument
-      story = Story.select_story(project, filter, root_branch_name = @options[:root_branch], is_hotfix = @options[:hotfix])
+      story = Story.select_story(@project, filter, 1, options = @options)
       Story.pretty_print story
       story.request_estimation! if story.unestimated?
-      story.create_branch!  
+      story.create_branch!
       @configuration.story = story # Tag the branch with story attributes
       Git.add_hook 'prepare-commit-msg', File.join(File.dirname(__FILE__), 'prepare-commit-msg.sh')
       story.mark_started!
@@ -19,8 +20,8 @@ module GithubPivotalFlow
         opts.banner = "Usage: git start <feature|chore|bug|story_id>"
         opts.on("-t", "--api-token=", "Pivotal Tracker API key") { |k| options[:api_token] = k }
         opts.on("-p", "--project-id=", "Pivotal Tracker project id") { |p| options[:project_id] = p }
-        opts.on("-r", "--root-branch=", "Root branch") { |r| options[:root_branch] = r }
-        opts.on("-f", "--hotfix", "Hotfix") { |h| options[:hotfix] = true }
+        opts.on("-r", "--root-branch-name=", "Root branch name") { |r| options[:root_branch_name] = r }
+        opts.on("-f", "--hotfix", "Hotfix") { |h| options[:is_hotfix] = true }
 
         opts.on_tail("-h", "--help", "This usage guide") { put opts.to_s; exit 0 }
       end.parse!(args)

--- a/lib/github_pivotal_flow/start.rb
+++ b/lib/github_pivotal_flow/start.rb
@@ -7,6 +7,7 @@ module GithubPivotalFlow
       story = Story.select_story @project, filter
       Story.pretty_print story
       story.request_estimation! if story.unestimated?
+      options[:root_branch] = Git.get_config(KEY_MASTER_BRANCH, :inherited) if filter == 'hotfix'
       story.create_branch! options[:root_branch]
       @configuration.story = story # Tag the branch with story attributes
       Git.add_hook 'prepare-commit-msg', File.join(File.dirname(__FILE__), 'prepare-commit-msg.sh')

--- a/lib/github_pivotal_flow/start.rb
+++ b/lib/github_pivotal_flow/start.rb
@@ -5,7 +5,7 @@ module GithubPivotalFlow
     def run!
       filter = [@options[:args]].flatten.first
       #TODO: Validate the format of the filter argument
-      story = Story.select_story(@project, filter, 1, options = @options)
+      story = Story.select_story(@project, filter, 5, options = @options)
       Story.pretty_print story
       story.request_estimation! if story.unestimated?
       story.create_branch!

--- a/lib/github_pivotal_flow/start.rb
+++ b/lib/github_pivotal_flow/start.rb
@@ -7,7 +7,7 @@ module GithubPivotalFlow
       story = Story.select_story @project, filter
       Story.pretty_print story
       story.request_estimation! if story.unestimated?
-      story.create_branch!
+      story.create_branch! options[:root_branch]
       @configuration.story = story # Tag the branch with story attributes
       Git.add_hook 'prepare-commit-msg', File.join(File.dirname(__FILE__), 'prepare-commit-msg.sh')
       story.mark_started!
@@ -21,6 +21,7 @@ module GithubPivotalFlow
         opts.banner = "Usage: git start <feature|chore|bug|story_id>"
         opts.on("-t", "--api-token=", "Pivotal Tracker API key") { |k| options[:api_token] = k }
         opts.on("-p", "--project-id=", "Pivotal Tracker project id") { |p| options[:project_id] = p }
+        opts.on("-r", "--root-branch=", "Root branch") { |r| options[:root_branch] = r }
 
         opts.on_tail("-h", "--help", "This usage guide") { put opts.to_s; exit 0 }
       end.parse!(args)

--- a/lib/github_pivotal_flow/story.rb
+++ b/lib/github_pivotal_flow/story.rb
@@ -1,7 +1,8 @@
 # Utilities for dealing with +PivotalTracker::Story+s
 module GithubPivotalFlow
   class Story
-    attr_accessor :pivotal_story, :project, :branch_name, :root_branch_name, :user_defined_root_branch_name, :is_hotfix
+    attr_accessor :pivotal_story, :project, :branch_name, :root_branch_name
+    attr :is_hotfix, :user_defined_root_branch_name
 
     # Print a human readable version of a story.  This pretty prints the title,
     # description, and notes for the story.
@@ -44,7 +45,7 @@ module GithubPivotalFlow
       else
         story = find_story project, filter, limit
       end
-      self.new(project, story, root_branch_name = root_branch_name)
+      self.new(project, story, root_branch_name = root_branch_name, is_hotfix = is_hotfix)
     end
 
     # @param [Project] project the Project for this repo
@@ -57,6 +58,7 @@ module GithubPivotalFlow
       @user_defined_root_branch_name = options[:root_branch_name]
       @branch_suffix = @branch_name.split('-').last if @branch_name
       @branch_suffix ||= nil
+      @is_hotfix = options[:is_hotfix]
     end
 
     def release?

--- a/lib/github_pivotal_flow/story.rb
+++ b/lib/github_pivotal_flow/story.rb
@@ -185,9 +185,7 @@ module GithubPivotalFlow
     end
 
     def root_branch_name
-      root = Git.get_config(KEY_ROOT_BRANCH, :branch)
-      puts "Root branch name #{root}"
-      return root
+      Git.get_config(KEY_ROOT_BRANCH, :branch)
     end
 
     def determine_root_branch_name

--- a/lib/github_pivotal_flow/version.rb
+++ b/lib/github_pivotal_flow/version.rb
@@ -1,3 +1,3 @@
 module GithubPivotalFlow
-  VERSION = '1.2'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
Couple things going on here:
- Allow creation of hotfix stories at command line. Since pivotal doesn't support a 'hotfix' story type I just added a flag, and then an ivar on Story. Then on all branches that should merge to `master_branch_name` (including hotfix stories), we also merge to `develop_branch_name`
  - I'm aware you can add a label in pivotal to a task, and left that as an alternate option
- It's often beneficial to create stories based off a non-master/develop branch (like when working bugs on a release branch). Pass -r branch_name to specify that
- Finally, I'm personally a fan of creating a PR for release branches, so there's a central place for the team to review final tweaks/fixes before merging the release.

Let me know what you think.
